### PR TITLE
Update metadata_search.yaml

### DIFF
--- a/0_blob_fish/api_definitions/rest/metadata_search.yaml
+++ b/0_blob_fish/api_definitions/rest/metadata_search.yaml
@@ -119,7 +119,7 @@ paths:
         schema:
           $ref: '#/components/schemas/DocumentType'
       - in: query
-        name: facet
+        name: return_facets
         required: false
         schema:
           default: false

--- a/0_blob_fish/api_definitions/rest/metadata_search.yaml
+++ b/0_blob_fish/api_definitions/rest/metadata_search.yaml
@@ -21,6 +21,20 @@ components:
         - option
       additionalProperties: false
 
+    FilterOption:
+      properties:
+        key:
+          title: Key
+          type: string
+        value:
+          title: Value
+          type: string
+      required:
+        - key
+        - value
+      title: FilterOption
+      type: object
+
     Facet:
       type: object
       properties:
@@ -36,17 +50,17 @@ components:
       additionalProperties: false
 
     SearchQuery:
-      type: object
+      description: Represents the Search Query.
       properties:
-        # please provide at least one of the following properties:
-        q:
+        filters:
+          $ref: '#/components/schemas/FilterOption'
+        query:
+          title: Query
           type: string
-          description: query string
-        facets:
-          type: object
       required:
-        - q
-      additionalProperties: false
+        - query
+      title: SearchQuery
+      type: object
 
     SearchHit:
       type: object
@@ -94,14 +108,14 @@ paths:
   /rpc/search:
     post:
       operationId: search
-      summary: Search metadata catalog by keywords and facets
+      summary: Search metadata catalog by keywords and filters
       requestBody:
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/SearchQuery"
         description: >-
-          Search keywords and facets.
+          Search keywords and filters.
       responses:
         "200":
           content:

--- a/0_blob_fish/api_definitions/rest/metadata_search.yaml
+++ b/0_blob_fish/api_definitions/rest/metadata_search.yaml
@@ -53,7 +53,9 @@ components:
       description: Represents the Search Query.
       properties:
         filters:
-          $ref: '#/components/schemas/FilterOption'
+          type: array
+          items:
+            $ref: '#/components/schemas/FilterOption'
         query:
           title: Query
           type: string

--- a/0_blob_fish/api_definitions/rest/metadata_search.yaml
+++ b/0_blob_fish/api_definitions/rest/metadata_search.yaml
@@ -3,12 +3,13 @@ components:
     DocumentType:
       type: string
       enum:
-        # to be adjusted
-        - File
-        - Publication
-        - Experiment
-        - Study
         - Dataset
+        - Project
+        - Study
+        - Experiment
+        - Sample
+        - Publication
+        - File
 
     FacetOption:
       type: object
@@ -111,6 +112,33 @@ paths:
     post:
       operationId: search
       summary: Search metadata catalog by keywords and filters
+      parameters:
+      - in: query
+        name: document_type
+        required: true
+        schema:
+          $ref: '#/components/schemas/DocumentType'
+      - in: query
+        name: facet
+        required: false
+        schema:
+          default: false
+          title: Facet
+          type: boolean
+      - in: query
+        name: skip
+        required: false
+        schema:
+          default: 0
+          title: Skip
+          type: integer
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 10
+          title: Limit
+          type: integer
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Title for squash and merge:
```
Update SearchQuery and add FilterOption
```

Description for squash and merge:
```
- Rename 'q' to 'query' in 'SearchQuery' object
- Rename 'facets' to 'filters' in 'SearchQuery' object
```


**Rationale:** While we want to filter based on the outcome of facets, the SearchQuery needs to be generic enough. Any filter (be it a field or a facet field) will be supplied as a key-value pair in `filters` section of the SearchQuery object