### PR TITLE
Add count to SearchResult

### DIFF
--- a/0_blob_fish/api_definitions/rest/metadata_search.yaml
+++ b/0_blob_fish/api_definitions/rest/metadata_search.yaml
@@ -90,6 +90,7 @@ components:
       properties:
         count:
           type: int
+          description: Total number of hits.
         hits:
           type: array
           items:

--- a/0_blob_fish/api_definitions/rest/metadata_search.yaml
+++ b/0_blob_fish/api_definitions/rest/metadata_search.yaml
@@ -88,6 +88,8 @@ components:
     SearchResult:
       type: object
       properties:
+        count:
+          type: int
         hits:
           type: array
           items:


### PR DESCRIPTION
- Add count to SearchResult so that it is clear what the total number of hits are, even when paginating