### PR TITLE
[star-nosed mole] 1:1 relationship between files and uploads

### DIFF
--- a/4-star-nosed_mole/api_definitions/rest/ucs.yaml
+++ b/4-star-nosed_mole/api_definitions/rest/ucs.yaml
@@ -6,7 +6,6 @@ info:
 
 paths:
   /files/{file_id}:
-
     get:
       operationId: getFileMetadata
       description: Get file metadata including the current upload attempt.
@@ -29,9 +28,8 @@ paths:
             corresponding file.
         "404":
           description: The file with the given ID has not (yet) been registered for upload.
-          
-  /uploads:
 
+  /uploads:
     post:
       operationId: createUpload
       description: Initiate a new mutli-part upload.
@@ -51,20 +49,14 @@ paths:
           description: |
             It is currently not possible to create a new upload for
             the file with the specified ID because another upload for that
-            file already exists and has not been completed yet
-            (its status is not "failed", "rejected", or "accepted").
+            file is already active or has been accepted
+            (its status is not "failed", "cancelled", or "rejected").
         "403":
           description: |
-            Either the user is not registered as a Data Submitter for the
+            The user is not registered as a Data Submitter for the
             corresponding file.
-            Or it is currently not possible to create a new upload for
-            the file with the specified ID because:
-              - a previous upload for that file was already accepted
-              - another upload for that file is currently in progress Or
-                is waiting for acceptance
 
   /uploads/{upload_id}:
-
     get:
       operationId: getUploadDetails
       description: Get details on a specific upload.
@@ -83,7 +75,7 @@ paths:
                 $ref: "#/components/schemas/UploadDetails"
         "403":
           description: |
-            Either the user is not registered as a Data Submitter for the
+            The user is not registered as a Data Submitter for the
             file corresponding to this upload.
         "404":
           description: The upload with the given ID does not exist (anymore).
@@ -160,7 +152,6 @@ components:
           description: The ID of the file corresponding to this upload.
       required:
         - upload_id
-
 
     UploadDetails:
       title: Multi-Part Upload Details

--- a/4-star-nosed_mole/api_definitions/rest/ucs.yaml
+++ b/4-star-nosed_mole/api_definitions/rest/ucs.yaml
@@ -5,10 +5,11 @@ info:
   version: 0.2.0
 
 paths:
-  /files/{file_id}/uploads:
-    post:
-      operationId: createUpload
-      description: Initiate a new mutli-part upload.
+  /files/{file_id}:
+
+    get:
+      operationId: getFileMetadata
+      description: Get file metadata including the current upload attempt.
       parameters:
         - name: file_id
           in: path
@@ -17,11 +18,41 @@ paths:
             type: string
       responses:
         "200":
+          description: File metadata including the current upload attempt
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FileMetadata"
+        "403":
+          description: |
+            The user is not registered as a Data Submitter for the
+            corresponding file.
+        "404":
+          description: The file with the given ID has not (yet) been registered for upload.
+          
+  /uploads:
+
+    post:
+      operationId: createUpload
+      description: Initiate a new mutli-part upload.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UploadCreation"
+      responses:
+        "200":
           description: Details on the newly created upload.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/UploadDetails"
+        "400":
+          description: |
+            It is currently not possible to create a new upload for
+            the file with the specified ID because another upload for that
+            file already exists and has not been completed yet
+            (its status is not "failed", "rejected", or "accepted").
         "403":
           description: |
             Either the user is not registered as a Data Submitter for the
@@ -31,49 +62,32 @@ paths:
               - a previous upload for that file was already accepted
               - another upload for that file is currently in progress Or
                 is waiting for acceptance
-        "404":
-          description: The file with the given ID has not (yet) been registered for upload.
+
+  /uploads/{upload_id}:
 
     get:
-      operationId: getPendingUploads
-      description: |
-        Get all multi-part uploads (can only be 1 or none) which are currently pending.
-        E.g. this endpoint is useful if the client has lost the ID of the currently ongoing
-        upload.
+      operationId: getUploadDetails
+      description: Get details on a specific upload.
       parameters:
-        - name: file_id
+        - name: upload_id
           in: path
           required: true
           schema:
             type: string
-        - name: status
-          in: query
-          description: |
-            The status of the multi-part upload, only "pending" is allowed as
-            the single option.
-          required: true
-          schema:
-            type: string
-            enum: ["pending"]
       responses:
         "200":
-          description: |
-            List of pending multi-part uploads and their details.
-            Please note, the list may either contain 1 or 0 elements.
+          description: Details on a specific upload.
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/UploadDetails"
+                $ref: "#/components/schemas/UploadDetails"
         "403":
           description: |
-            The user is not registered as a Data Submitter for the
-            corresponding file.
+            Either the user is not registered as a Data Submitter for the
+            file corresponding to this upload.
         "404":
-          description: The file with the given ID has not (yet) been registered for upload.
+          description: The upload with the given ID does not exist (anymore).
 
-  /uploads/{upload_id}:
     patch:
       operationId: updateUploadStatus
       description: |
@@ -137,18 +151,34 @@ paths:
 
 components:
   schemas:
+    UploadCreation:
+      title: Properties required to create a new upload
+      type: object
+      properties:
+        file_id:
+          type: string
+          description: The ID of the file corresponding to this upload.
+      required:
+        - upload_id
+
+
     UploadDetails:
       title: Multi-Part Upload Details
       type: object
       properties:
         upload_id:
           type: string
+        file_id:
+          type: string
+          description: The ID of the file corresponding to this upload.
         part_size:
           type: integer
           description: Part size in bytes.
       required:
         - upload_id
+        - file_id
         - part_size
+
     UploadUpdate:
       title: Multi-Part Upload Update
       type: object
@@ -158,3 +188,42 @@ components:
           enum:
             - uploaded
             - cancelled
+
+    FileMetadata:
+      title: Multi-Part Upload Details
+      type: object
+      properties:
+        file_id:
+          type: string
+        file_name:
+          type: string
+        md5_checksum:
+          type: string
+        size:
+          type: integer
+          minimum: 0
+        grouping_label:
+          type: string
+        creation_date:
+          type: string
+          format: date-time
+        update_date:
+          type: string
+          format: date-time
+        format:
+          type: string
+        current_upload_id:
+          description: |
+            ID of the current upload. `Null` if no update has been
+            initiated, yet.
+          type: string
+          nullable: true
+      required:
+        - file_id
+        - file_name
+        - md5_checksum
+        - grouping_label
+        - creation_date
+        - update_date
+        - format
+        - current_upload_id


### PR DESCRIPTION
For squash and merge:

```
Restructured API to resemble a 1:1 relationship
between files and uploads.

Endpoints added:
  - GET /files/{file_id} (among other returns the id of
     the current upload)
  - POST /uploads
  - GET /uploads/{upload_id}

Removed endpoints:
  - POST /files/{file_id}/uploads
  - GET /files/{file_id}/uploads==pending

Finding out details for the current upload attempt of
a given file is now a two step procedure:
1. GET /files/{file_id} -> obtain upload_id
2. GET /uploads/{upload_id} -> obtain part_size
```

Sorry, Moritz, even more changes to the API. But now it is much more standard REST. Let me know what you think.