### PR TITLE
Change status to upload_status, add a 400 return for the patch endpoint

### DIFF
--- a/4-star-nosed_mole/api_definitions/rest/ucs.yaml
+++ b/4-star-nosed_mole/api_definitions/rest/ucs.yaml
@@ -101,8 +101,8 @@ paths:
           description: Multi-part upload successfully updated.
         "400":
           description: |
-            The multi-part upload with the given ID can't be
-            set to this status.
+            Cannot set invalid status for multi-part upload
+            with the given ID.
         "403":
           description: |
             The user is not registered as a Data Submitter for the

--- a/4-star-nosed_mole/api_definitions/rest/ucs.yaml
+++ b/4-star-nosed_mole/api_definitions/rest/ucs.yaml
@@ -99,6 +99,10 @@ paths:
       responses:
         "204":
           description: Multi-part upload successfully updated.
+        "400":
+          description: |
+            The multi-part upload with the given ID can't be
+            set to this status.
         "403":
           description: |
             The user is not registered as a Data Submitter for the
@@ -174,7 +178,7 @@ components:
       title: Multi-Part Upload Update
       type: object
       properties:
-        status:
+        upload_status:
           type: string
           enum:
             - uploaded


### PR DESCRIPTION
Using status in a HTML GET url produces errors.

Status has to be changed to upload_status everywhere
Added the possibility for a 400 error
