### PR TITLE
change invalid change error code

### DIFF
--- a/4-star-nosed_mole/api_definitions/rest/ucs.yaml
+++ b/4-star-nosed_mole/api_definitions/rest/ucs.yaml
@@ -117,15 +117,13 @@ paths:
         "400":
           description: |
             Exceptions by ID:
-              - pendingInvalidChange: Cannot change status from pending to accepted or rejected
-              - uploadedInvalidChange: Cannot change status from uploaded to cancelled or pending
-              - invalidChangeFromCancelled: Cannot change status from cancelled for this upload attempt.
+              - invalidChangeFromCancelled: Cannot update an upload with status cancelled.
                 If you want to restart, initiate a new multi-part upload instead.
               - invalidChangeFromFailed: Cannot change status from failed for this upload attempt.
                 If you want to restart, initiate a new multi-part upload instead.
-              - invalidChangeFromAccepted: Upload has already been accepted, a status change or
-                new upload attempt is no longer possible.
-              - invalidChangeFromRejected: Cannot change status from rejected for this upload attempt.
+              - invalidChangeFromUploaded: Cannot update an upload with status uploaded.
+              - invalidChangeFromAccepted: Cannot update an upload with status accepted.
+              - invalidChangeFromRejected: Cannot update an upload with status cancelled.
                 If you want to restart, initiate a new multi-part upload instead.
         "403":
           description: |


### PR DESCRIPTION
Changes to something else then "cancelled" or  "uploaded" are not
allowed by the openapi doc and
will result in an validation error.
No need to specifically report this
usage error (the client should
know how to use our API).