### PR TITLE
Pied raven gdev 1392

### DIFF
--- a/19-pied-raven/api_definitions/rest/encryption_key_store.yml
+++ b/19-pied-raven/api_definitions/rest/encryption_key_store.yml
@@ -1,0 +1,199 @@
+openapi: 3.0.3
+
+info:
+  title: Encryption Key Store
+  version: 0.1.0
+
+paths:
+  /secrets:
+    post:
+      operationId: postEncryptionSecrets
+      summary: Extract file encryption/decryption secret and file content offset from enevelope
+      description: |
+        Extract file encryption/decryption secret, create secret ID and extract file content offset.
+        Saves first two in a secure store, returns all three to caller.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InboundEnvelopeQuery"
+
+      responses:
+        "200":
+          description: |
+            Information extracted from envelope
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InboundEnvelopeContent"
+        "400":
+          description: Envelope malformed or missing
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MalformedOrMissingEnvelopeError"
+        "403":
+          description: Could not decrypt envelope content with given keys
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnvelopeDecryptionError"
+
+  /secrets/{secret_id}/envelopes/{client_pk}:
+    get:
+      operationId: getPersonalizedEnvelope
+      summary: Get personalized envelope containing Crypt4GH file encryption/decryption key
+      description: |
+        A Crypt4GH file envelope is created on demand using the corresponding file encryption/decryption secret,
+        the current GHGA secret key and the download user's private key.
+      parameters:
+        - name: secret_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: client_pk
+          in: path
+          description: The public key of the client.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Envelope was successfully created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OutboundEnvelope"
+        "404":
+          description: |
+            Returned when either the file ID or public key is not known to the service.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/SecretNotFoundError"
+
+components:
+  schemas:
+    OutboundEnvelope:
+      title: Personalized Envelope
+      description: |
+        Crypt4GH Envelope generated with GHGA secret key and download user public key.
+        Contains file encryption/decryption secret.
+      type: object
+      properties:
+        content:
+          type: string
+          format: bytes
+      required:
+        - content
+
+    InboundEnvelopeContent:
+      title: Envelope Content
+      description: |
+        Contains file encryption/decryption secret extracted from file envelope, the ID generated for this secret
+        and the file content offset, i.e. the location of the encrypted file content within the file.
+      type: object
+      properties:
+        secret:
+          type: string
+          format: bytes
+        secret_id:
+          type: string
+        offset:
+          type: integer
+          minimum: 0
+      required:
+        - secret
+        - secret_id
+        - offset
+
+    EnvelopeDecryptionError:
+      title: EnvelopeDecryptionError
+      description:
+        Error thrown when no available secret crypt4GH key can successfully decrypt the
+        file envelope.
+      type: object
+      properties:
+        description:
+          description:
+            A human readable message to the client explaining the cause
+            of the exception.
+          title: Description
+          type: string
+        exception_id:
+          enum:
+            - EnvelopeDecryptionError
+          title: Exceptionid
+          type: string
+
+    InboundEnvelopeQuery:
+      title: Envelope Query
+      description: Request object containing first file part and user ID.
+      type: object
+      properties:
+        client_pk:
+          type: string
+        file_part:
+          type: string
+          format: bytes
+          description: First file part from inbox, containing the envelope.
+      required:
+        - user_id
+        - file_part
+
+    SecretNotFoundError:
+      title: SecretNotFoundError
+      description: No secret with the given ID is known.
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/SecretNotFoundErrorData"
+        description:
+          description:
+            A human readable message to the client explaining the cause
+            of the exception.
+          title: Description
+          type: string
+        exception_id:
+          enum:
+            - SecretNotFoundError
+          title: Exceptionid
+          type: string
+
+    SecretNotFoundErrorData:
+      title: SecretNotFoundErrorData
+      description: Model for exception data
+      type: object
+      properties:
+        secret_id:
+          title: Secret Id
+          type: string
+      required:
+        - secret_id
+
+    MalformedOrMissingEnvelopeError:
+      title: MalformedOrMissingEnvelopeError
+      description: Envelope decryption fails due to missing or malformed envelope.
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/MalformedOrMissingEnvelopeErrorData"
+        description:
+          description:
+            A human readable message to the client explaining the cause
+            of the exception.
+          title: Description
+          type: string
+        exception_id:
+          enum:
+            - MalformedOrMissingEnvelopeError
+          title: Exceptionid
+          type: string
+
+    MalformedOrMissingEnvelopeErrorData:
+      title: MalformedOrMissingEnvelopeErrorData
+      description: Model for exception data
+      type: object

--- a/19-pied-raven/technical_specification.md
+++ b/19-pied-raven/technical_specification.md
@@ -1,0 +1,28 @@
+# File Encryption & Decryption Service Integration (Pied Crow)
+**Epic Type:** Implementation Epic
+
+
+## Scope:
+A scope definition can be found here: https://wiki.verbis.dkfz.de/x/4AC2D
+## User Journeys
+
+Building on the [*18 - Hooded Crow*](../18-hooded-crow/technical_specification.md) epic, this epic aims to finish the work started on the encryption & decryption services, integrating them into the wider GHGA microservice landscape and resolving remaining questions and issues.
+
+### 1. TODO:
+
+## User Journeys that are not part of this Epic:
+
+## API Definitions:
+
+### RESTful/Synchronous:
+[Encryption Key Store REST API](./api_definitions/rest/encryption_key_store.yml) - [Swagger UI](https://editor.swagger.io/?url=https://raw.githubusercontent.com/ghga-de/epic-docs/main/19-pied-raven/api_definitions/rest/encryption_key_store.yml) - This supersedes the 18 Hooded Crow version.
+
+## Additional Implementation Details:
+
+
+
+## Human Resource/Time Estimation:
+
+Number of sprints required: 2
+
+Number of developers required: 2

--- a/19-pied-raven/technical_specification.md
+++ b/19-pied-raven/technical_specification.md
@@ -38,8 +38,9 @@ This includes moving (remaining) in-service event definitions to the https://git
 As all services dealing with file upload/download/encryption/decryption interact with each other, either during upload or download, a local setup to test functionality across all services would be beneficial.
 This would allow to capture issues early and replace mocks with actual data to see how well our microservice architecture performs.
 
-The implementation of this journey consists of providing a docker-compose file that yields a working local setup.
-A minimal test case ensuring functionality should be included.
+The implementation of this journey consists of:
+- a docker-compose for local deployment of all services along with relying infrastructure (MongoDB, HashiCorp Vault, Apache Kafka, LocalStack S3)
+- one or more minimal test cases that set up certain states in the infrastructure and simulate a basic user journey involving all the services
 
 ## Optional User Journeys:
 

--- a/19-pied-raven/technical_specification.md
+++ b/19-pied-raven/technical_specification.md
@@ -15,26 +15,16 @@ The API should allow to store a secret and return a newly generated ID by which 
 
 Implementing this change includes multiple steps:
 
-1. Eplore how to set up HashiCorp Vault for our use case
+1. Eplore how to set up HashiCorp Vault for our use case - see also https://wiki.verbis.dkfz.de/x/SoKcCw for what has already been done
 2. Explore how to connect, store and retrieve secrets
-3. Provide a synchronous API for communication with the Vault
+3. Implement a HashiCorp vault setup for development (.devcontainer) and testing (python-testcontainers).
 
-### 2. Integrate with and adapt adjacent services
-Both the Encryption Key Store and the Interrogation Room depend on (synchronous and asynchronous) communication with other services.
-Interaction with the respective service on side of the caller/receiver is not implemented yet.
-Check and adjust all of the following services:
-
-1. Upload Controller - outbound event signaling file upload completed to Interrogation Room
-2. Upload Controller - handling of failure event from Interrogation Room
-3. Internal File Registry - handling of success event from Interrogation Room
-4. Download Controller - request and receive envelope, attach envelope to outgoing file cotent
-
-### 3. Finalize request/response models and incoming/outgoing events
+### 2. Finalize request/response models and incoming/outgoing events
 While models and events exist for all the necessary cross-service communication, some have a more prototypical character and might need updates to their definition based on spec compliance or practical concerns.
 Those updates should be applied after all services can communicate with each other.
 This includes moving (remaining) in-service event definitions to the https://github.com/ghga-de/ghga-event-schemas repository.
 
-### 4. Provide a local testbed covering all services using docker-compose
+### 3. Provide a local testbed covering all services using docker-compose
 As all services dealing with file upload/download/encryption/decryption interact with each other, either during upload or download, a local setup to test functionality across all services would be beneficial.
 This would allow to capture issues early and replace mocks with actual data to see how well our microservice architecture performs.
 
@@ -43,12 +33,20 @@ The implementation of this journey consists of:
 - one or more minimal test cases that set up certain states in the infrastructure and simulate a basic user journey involving all the services
 
 ## Optional User Journeys:
+### Integrate with and adapt adjacent services
+Both the Encryption Key Store and the Interrogation Room depend on (synchronous and asynchronous) communication with other services.
+Interaction with the respective service on side of the caller/receiver is not implemented yet.
+Check and adjust all of the following services:
 
-### 1. Decide on user public key propagation/storage/retrieval mechanism
+1. Upload Controller - outbound event signaling file upload completed to Interrogation Room
+2. Upload Controller - handling of failure event from Interrogation Room
+3. Internal File Registry - handling of success event from Interrogation Room
+4. Download Controller - request and receive envelope, attach envelope to outgoing file cotent
+## User Journeys that are not part of this Epic:
+### Decide on user public key propagation/storage/retrieval mechanism
 Currently a user's public key is piped through the interrogation room into the encryption key store.
 We need to discuss specifics of public key propagation and storage, as this permeates some of the models/events and issues like source of truth and expulsion of keys need to be resolved.
 However, this might be more fitting to consider in conjunction with a refactoring step for integration with the auth story.
-## User Journeys that are not part of this Epic:
 
 ## API Definitions:
 
@@ -62,4 +60,4 @@ However, this might be more fitting to consider in conjunction with a refactorin
 
 Number of sprints required: 2-3
 
-Number of developers required: 2
+Number of developers required: 3

--- a/19-pied-raven/technical_specification.md
+++ b/19-pied-raven/technical_specification.md
@@ -8,8 +8,45 @@ A scope definition can be found here: https://wiki.verbis.dkfz.de/x/4AC2D
 
 Building on the [*18 - Hooded Crow*](../18-hooded-crow/technical_specification.md) epic, this epic aims to finish the work started on the encryption & decryption services, integrating them into the wider GHGA microservice landscape and resolving remaining questions and issues.
 
-### 1. TODO:
+### 1. Enable Encryption Key Store service to use HashiCorp Vault for secure storage and retrieval of file secrets
+File secrets are currently stored in a MongoDB attached to the Encryption Key Store.
+For safe storage concerns this should be replaced with HashiCorp Vault instead.
+The API should allow to store a secret and return a newly generated ID by which this secret can be retrieved.
 
+Implementing this change includes multiple steps:
+
+1. Eplore how to set up HashiCorp Vault for our use case
+2. Explore how to connect, store and retrieve secrets
+3. Provide a synchronous API for communication with the Vault
+
+### 2. Integrate with and adapt adjacent services
+Both the Encryption Key Store and the Interrogation Room depend on (synchronous and asynchronous) communication with other services.
+Interaction with the respective service on side of the caller/receiver is not implemented yet.
+Check and adjust all of the following services:
+
+1. Upload Controller - outbound event signaling file upload completed to Interrogation Room
+2. Upload Controller - handling of failure event from Interrogation Room
+3. Internal File Registry - handling of success event from Interrogation Room
+4. Download Controller - request and receive envelope, attach envelope to outgoing file cotent
+
+### 3. Finalize request/response models and incoming/outgoing events
+While models and events exist for all the necessary cross-service communication, some have a more prototypical character and might need updates to their definition based on spec compliance or practical concerns.
+Those updates should be applied after all services can communicate with each other.
+This includes moving (remaining) in-service event definitions to the https://github.com/ghga-de/ghga-event-schemas repository.
+
+### 4. Provide a local setup covering all services using docker-compose
+As all services dealing with file upload/download/encryption/decryption interact with each other, either during upload or download, a local setup to test functionality across all services would be beneficial.
+This would allow to capture issues early and replace mocks with actual data to see how well our microservice architecture performs.
+
+The implementation of this journey consists of providing a docker-compose file that yields a working local setup.
+A minimal test case ensuring functionality should be included.
+
+## Optional User Journeys:
+
+### 1. Decide on user public key propagation/storage/retrieval mechanism
+Currently a user's public key is piped through the interrogation room into the encryption key store.
+We need to discuss specifics of public key propagation and storage, as this permeates some of the models/events and issues like source of truth and expulsion of keys need to be resolved.
+However, this might be more fitting to consider in conjunction with a refactoring step for integration with the auth story.
 ## User Journeys that are not part of this Epic:
 
 ## API Definitions:
@@ -20,9 +57,8 @@ Building on the [*18 - Hooded Crow*](../18-hooded-crow/technical_specification.m
 ## Additional Implementation Details:
 
 
-
 ## Human Resource/Time Estimation:
 
-Number of sprints required: 2
+Number of sprints required: 2-3
 
 Number of developers required: 2

--- a/19-pied-raven/technical_specification.md
+++ b/19-pied-raven/technical_specification.md
@@ -34,7 +34,7 @@ While models and events exist for all the necessary cross-service communication,
 Those updates should be applied after all services can communicate with each other.
 This includes moving (remaining) in-service event definitions to the https://github.com/ghga-de/ghga-event-schemas repository.
 
-### 4. Provide a local setup covering all services using docker-compose
+### 4. Provide a local testbed covering all services using docker-compose
 As all services dealing with file upload/download/encryption/decryption interact with each other, either during upload or download, a local setup to test functionality across all services would be beneficial.
 This would allow to capture issues early and replace mocks with actual data to see how well our microservice architecture performs.
 


### PR DESCRIPTION
```
Technical specifications for the 19 Pied Raven epic
```

REST spec for eks is currently copied from Hooded Crow -> Should we keep that there, move it here, keep duplicates?
Journeys might need a bit more of a step-by-step structure.
Please check if something is missing that should be part of the integration process.
Probably need to update the epic docs already.