### PR TITLE
tech spec

### DIFF
--- a/50-dhole/technical_specification.md
+++ b/50-dhole/technical_specification.md
@@ -1,0 +1,46 @@
+# Rewriting existing metldata transformations
+**Epic Type:** Implementation Epic
+
+Epic planning and implementation follow the
+[Epic Planning and Marathon SOP](https://docs.ghga-dev.de/main/sops/sop001_epic_planning.html).
+
+**Attention: Please do not put any confidential content here.**
+
+## Scope
+### Outline:
+The aim is to rewrite all existing metldata transformations to use schemapack.
+
+
+### Included/Required:
+- add possibility to use custom embedding profile to configure the denormalization
+  in schemapack
+- migrating the already schemapack-based transformations to spec version 0.2.0
+  (see https://github.com/ghga-de/metldata/tree/poc/src/metldata/schemapack_/builtin_transformations):
+  - delete_properties
+  - infer_relations
+- re-implement the following LinkML-based transformations to use schemapack
+  (see https://github.com/ghga-de/metldata/tree/poc/src/metldata/builtin_transformations):
+  - merge_slots
+- re-evaluate and potentially refactor the following transformations:
+  - aggregate
+  - normalize_model
+
+
+### Not included:
+- Reimplementation of the custom_ebeddings transformation is not required since it will already
+  covered by builtin functionality of schemapack
+- Reimplementation of the add_accessions transformation is postponed since it might be
+  moved handled by the submission store and not be implemented as transformation.
+- A full reimplementation of the GHGA transformation workflow (this depends on other changes to
+  be in place first and would make this epic dependent on other lines of work).
+
+## Additional Details:
+
+### Embedding Profile to Configure Denormalization:
+TBD.
+
+## Human Resource/Time Estimation:
+
+Number of sprints required: 2
+
+Number of developers required: 1


### PR DESCRIPTION
First draft of the tech spec for rewriting metldata transformations.

Many more details should be added especially around:
- the embedding profiles in schemapack
- the potential refactoring of the aggregate and normilze_model transformations
- general guidelines on how to use schemapack and datapack