### PR TITLE
Added details on outbox config changes

### DIFF
--- a/52-hero-shrew/technical_specification.md
+++ b/52-hero-shrew/technical_specification.md
@@ -60,7 +60,7 @@ The following services need the outbox *subscriber* implemented for the listed e
 
 ### Config Changes
 
-The outbox pattern implementation results in changes to service configuration parameters as follows
+The outbox pattern implementation results in changes to service configuration parameters as follows:
 
 #### Download Controller:
 Added `unstaged_download_collection` without default value  

--- a/52-hero-shrew/technical_specification.md
+++ b/52-hero-shrew/technical_specification.md
@@ -64,6 +64,7 @@ The outbox pattern implementation results in changes to service configuration pa
 
 #### Download Controller:
 Added `unstaged_download_collection` without default value  
+Removed `unstaged_download_event_type`
 Removed `files_to_delete_type`
 
 #### File Ingest:

--- a/52-hero-shrew/technical_specification.md
+++ b/52-hero-shrew/technical_specification.md
@@ -58,6 +58,35 @@ The following services need the outbox *subscriber* implemented for the listed e
 | Upload Controller      | FileDeletionRequested  |
 
 
+### Config Changes
+
+The outbox pattern implementation results in changes to service configuration parameters as follows
+
+#### Download Controller:
+Added `unstaged_download_collection` without default value  
+Removed `files_to_delete_type`
+
+#### File Ingest:
+Added `db_connection_str` and `db_name`  
+Added `file_validations_collection` with default value `file-validations`  
+Removed `publisher_type`  
+Renamed `publisher_topic` -> `file_upload_validation_success_topic`
+
+#### Internal File Registry:
+Removed `files_to_delete_type`, `files_to_register_type`, `files_to_stage_type`
+
+#### Interrogation Room:
+Removed `upload_received_event_type`
+
+#### Purge Controller:
+Added `db_connection_str` and `db_name`  
+Added `file_deletions_collection` with default value `file-deletions`  
+Removed `files_to_delete_type`
+
+#### Upload Controller:
+Added `file_upload_received_collection` without default value  
+Renamed `upload_received_event_topic` -> `file_upload_received_topic`  
+Removed `upload_received_event_type`, `files_to_delete_type`
 
 ## Human Resource/Time Estimation:
 


### PR DESCRIPTION
This should now list all changes to configuration parameters induced by the outbox pattern implementation.

Collection names have an inconsistency with default names, i.e. either all of them or none should have a default.
Might need to change that and update this document again.