### PR TITLE
Oryx/Kafka config standardization epic (GSI-1386)

### DIFF
--- a/67-oryx/technical_specification.md
+++ b/67-oryx/technical_specification.md
@@ -71,15 +71,6 @@ concept. The result is a "shoehorned" process that actually needs a dedicated
 mechanism in `hexkit`. That mechanism, a class that mimics some of the outbox
 DAO's functionality, can be created in another epic.
 
-For this epic, **if** a config class in the chart below is *not*
-marked with "*(stateful)*" but the current corresponding event types *are* dictated
-by `hexkit`'s outbox pattern event types, **then**:
-1. The event type's configured value, after using the standardized classes, should be
-   temporarily set to `upserted` for continuity.
-   - The value can be set to something natural once the new persistent publisher class
-     is implemented.
-2. These are examples of places where the future stateless outbox DAO would be used.
-   - Not exhaustive -- most non-outbox events would be eligible
 
 ### Proposed Config Classes
 > (stateful) means these events communicate state and should use the outbox pattern
@@ -154,7 +145,6 @@ UCS:
 <td><pre><code>
 <strong>FileUploadReceivedEventsConfig</strong>:
    file_upload_received_event_topic
-   file_upload_received_event_type
 </code></pre></td>
 <td><pre><code>
 (each currently use hexkit's outbox pattern event type)
@@ -182,7 +172,6 @@ NS & NOS:
 <td><pre><code>
 <strong>FileStagingRequestedEventsConfig</strong>:
    files_to_stage_event_topic
-   files_to_stage_event_type
 </code></pre></td>
 <td><pre><code>
 (both currently use hexkit's outbox pattern event type)
@@ -223,7 +212,6 @@ DCS:
 <td><pre><code>
 <strong>FileDeletionRequestEventsConfig</strong>:
    file_deletion_request_event_topic
-   file_deletion_request_event_type
 </code></pre></td>
 <td><pre><code>
 (each currently use hexkit's outbox pattern event type)
@@ -249,7 +237,6 @@ IFRS, DCS, & UCS:
 <td><pre><code>
 <strong>FileInterrogationSuccessEventsConfig</strong>:
    file_interrogations_event_topic
-   interrogation_success_event_type
 </code></pre></td>
 <td><pre><code>
 (all currently use hexkit's outbox pattern event type)

--- a/67-oryx/technical_specification.md
+++ b/67-oryx/technical_specification.md
@@ -90,8 +90,8 @@ by `hexkit`'s outbox pattern event types, **then**:
 <td><pre><code>
 <strong>*DatasetEventsConfig</strong>:
    dataset_change_event_topic
-   dataset_deletion_type
-   dataset_upsertion_type
+   dataset_deletion_event_type
+   dataset_upsertion_event_type
 </code></pre></td>
 <td><pre><code>
 UMS:
@@ -113,7 +113,7 @@ Metldata:
 <strong>*ResourceEventsConfig</strong>:
    resource_change_event_topic
    resource_deletion_event_type
-   resource_upsertion_type
+   resource_upsertion_event_type
 </code></pre></td>
 <td><pre><code>
 Metldata & MASS:
@@ -151,7 +151,7 @@ UCS:
 <tr>
 <td><pre><code>
 <strong>FileUploadReceivedEventsConfig</strong>:
-   file_upload_received_topic
+   file_upload_received_event_topic
    file_upload_received_event_type
 </code></pre></td>
 <td><pre><code>
@@ -246,7 +246,7 @@ IFRS, DCS, & UCS:
 <tr>
 <td><pre><code>
 <strong>FileInterrogationSuccessEventsConfig</strong>:
-   file_interrogations_topic
+   file_interrogations_event_topic
    interrogation_success_event_type
 </code></pre></td>
 <td><pre><code>
@@ -261,7 +261,7 @@ IFRS:
 <tr>
 <td><pre><code>
 <strong>FileInterrogationFailureEventsConfig</strong>:
-   file_interrogations_topic
+   file_interrogations_event_topic
    interrogation_failure_event_type
 </code></pre></td>
 <td><pre><code>

--- a/67-oryx/technical_specification.md
+++ b/67-oryx/technical_specification.md
@@ -64,7 +64,7 @@ should be too.
 ### A Note on "Normal" Events Using the Outbox Pattern
 We have events that don't communicate state but that nevertheless use the
 outbox pattern solely for persistence. The motivation for storing these *stateless*
-events is to aid in application restoration following a sudden loss of Kafka data.
+events is to aid in application restoration following the loss of Kafka data.
 The `stateless` events that are persisted and published via the outbox pattern
 always use the `upserted` event type, because deletion isn't an applicable
 concept. The result is a "shoehorned" process that actually needs a dedicated

--- a/67-oryx/technical_specification.md
+++ b/67-oryx/technical_specification.md
@@ -7,8 +7,8 @@ Epic planning and implementation follow the
 ## Scope
 ### Outline:
 We have different configuration key names that refer to the same topic or type in
-different services, complicating the maintenance of both mental models and
-configuration is actually happening in our services with regard to Kafka. To clarify,
+different services, complicating the proper configuration of the services when they
+are deployed jointly. To clarify,
 "configuration" here means the various service-specific event publisher/subscriber
 and config schemas defined in Python code, which contain
 `"abc_topic"` and `"abc_type"` fields, *as well as* the values assigned for those

--- a/67-oryx/technical_specification.md
+++ b/67-oryx/technical_specification.md
@@ -72,7 +72,7 @@ mechanism in `hexkit`. That mechanism, a class that mimics some of the outbox
 DAO's functionality, can be created in another epic.
 
 For this epic, **if** a config class in the chart below is *not*
-marked with \* but the current corresponding event types *are* dictated
+marked with "*(stateful)*" but the current corresponding event types *are* dictated
 by `hexkit`'s outbox pattern event types, **then**:
 1. The event type's configured value, after using the standardized classes, should be
    temporarily set to `upserted` for continuity.
@@ -82,55 +82,57 @@ by `hexkit`'s outbox pattern event types, **then**:
    - Not exhaustive -- most non-outbox events would be eligible
 
 ### Proposed Config Classes
-> \* means these events communicate state and should use the outbox pattern
+> (stateful) means these events communicate state and should use the outbox pattern
+
+> \* means the marked config naming has changed
 
 <table>
 <tr><th>New Config Class </th><th>Replaces </th></tr>
 <tr>
 <td><pre><code>
-<strong>*DatasetEventsConfig</strong>:
+<strong>DatasetEventsConfig (stateful)</strong>:
    dataset_change_event_topic
-   dataset_deletion_event_type
    dataset_upsertion_event_type
+   dataset_deletion_event_type
 </code></pre></td>
 <td><pre><code>
 UMS:
-  dataset_deletion_event_topic
+  *dataset_deletion_event_topic
   dataset_deletion_event_type
 WPS & DINS:
   dataset_change_event_topic
-  dataset_deletion_event_type
   dataset_upsertion_event_type
+  dataset_deletion_event_type
 Metldata:
   dataset_change_event_topic
-  dataset_deletion_type
-  dataset_upsertion_type
+  *dataset_upsertion_type
+  *dataset_deletion_type
 </code></pre></td>
 </tr>
 
 <tr>
 <td><pre><code>
-<strong>*ResourceEventsConfig</strong>:
+<strong>ResourceEventsConfig (stateful)</strong>:
    resource_change_event_topic
-   resource_deletion_event_type
    resource_upsertion_event_type
+   resource_deletion_event_type
 </code></pre></td>
 <td><pre><code>
 Metldata & MASS:
   resource_change_event_topic
-  resource_upsertion_type
+  *resource_upsertion_type
   resource_deletion_event_type
 </code></pre></td>
 </tr>
 
 <tr>
 <td><pre><code>
-<strong>*UserEventsTopicConfig</strong>:
+<strong>UserEventsTopicConfig (stateful)</strong>:
    user_event_topic
 </code></pre></td>
 <td><pre><code>
 UMS & NOS:
-  user_events_topic
+  *user_events_topic
   (event type managed by hexkit)
 </code></pre></td>
 </tr>
@@ -157,9 +159,9 @@ UCS:
 <td><pre><code>
 (each currently use hexkit's outbox pattern event type)
 UCS:
-  file_upload_received_topic,
+  *file_upload_received_topic
 IRS:
-  upload_received_event_topic
+  *upload_received_event_topic
 </code></pre></td>
 </tr>
 
@@ -185,9 +187,9 @@ NS & NOS:
 <td><pre><code>
 (both currently use hexkit's outbox pattern event type)
 IFRS:
-  files_to_stage_topic
+  *files_to_stage_topic
 DCS:
-  unstaged_download_event_topic
+  *unstaged_download_event_topic
 </code></pre></td>
 </tr>
 
@@ -226,7 +228,7 @@ DCS:
 <td><pre><code>
 (each currently use hexkit's outbox pattern event type)
 PCS, IFRS, DCS, & UCS:
-  files_to_delete_topic
+  *files_to_delete_topic
 </code></pre></td>
 </tr>
 
@@ -252,9 +254,9 @@ IFRS, DCS, & UCS:
 <td><pre><code>
 (all currently use hexkit's outbox pattern event type)
 IRS & FIS:
-  file_upload_validation_success_topic
+  *file_upload_validation_success_topic
 IFRS:
-  files_to_register_topic
+  *files_to_register_topic
 </code></pre></td>
 </tr>
 
@@ -266,11 +268,11 @@ IFRS:
 </code></pre></td>
 <td><pre><code>
 IRS:
-  interrogation_topic
-  interrogation_failure_type
+  *interrogation_topic
+  *interrogation_failure_type
 UCS:
-  upload_rejected_event_topic
-  upload_rejected_event_type
+  *upload_rejected_event_topic
+  *upload_rejected_event_type
 </code></pre></td>
 </tr>
 
@@ -282,11 +284,11 @@ UCS:
 </code></pre></td>
 <td><pre><code>
 IFRS, DCS, IRS, DINS:
-  file_registered_event_topic
-  file_registered_event_type
+  *file_registered_event_topic
+  *file_registered_event_type
 UCS:
-  upload_accepted_event_topic
-  upload_accepted_event_type
+  *upload_accepted_event_topic
+  *upload_accepted_event_type
 </code></pre></td>
 </tr>
 
@@ -298,8 +300,8 @@ UCS:
 </code></pre></td>
 <td><pre><code>
 DCS:
-  files_to_register_topic
-  files_to_register_type
+  *files_to_register_topic
+  *files_to_register_type
 </code></pre></td>
 </tr>
 
@@ -311,7 +313,7 @@ DCS:
 </code></pre></td>
 <td><pre><code>
 NOS & ARS:
-  access_request_events_topic
+  *access_request_events_topic
   access_request_created_event_type
 </code></pre></td>
 </tr>
@@ -324,7 +326,7 @@ NOS & ARS:
 </code></pre></td>
 <td><pre><code>
 NOS & ARS:
-  access_request_events_topic
+  *access_request_events_topic
   access_request_allowed_event_type
 </code></pre></td>
 </tr>
@@ -337,7 +339,7 @@ NOS & ARS:
 </code></pre></td>
 <td><pre><code>
 NOS & ARS:
-  access_request_events_topic
+  *access_request_events_topic
   access_request_denied_event_type
 </code></pre></td>
 </tr>
@@ -353,7 +355,7 @@ NOS:
   iva_state_changed_event_topic
   iva_state_changed_event_type
 UMS:
-  iva_events_topic
+  *iva_events_topic
   iva_state_changed_event_type
 </code></pre></td>
 </tr>
@@ -366,10 +368,10 @@ UMS:
 </code></pre></td>
 <td><pre><code>
 NOS:
-  second_factor_recreated_event_topic
+  *second_factor_recreated_event_topic
   second_factor_recreated_event_type
 UMS:
-  auth_events_topic
+  *auth_events_topic
   second_factor_recreated_event_type
 </code></pre></td>
 </tr>

--- a/67-oryx/technical_specification.md
+++ b/67-oryx/technical_specification.md
@@ -1,0 +1,374 @@
+# Kafka Event Config Standardization (Oryx)
+**Epic Type:** Implementation Epic
+
+Epic planning and implementation follow the
+[Epic Planning and Marathon SOP](https://docs.ghga-dev.de/main/sops/sop001_epic_planning.html).
+
+## Scope
+### Outline:
+We have different configuration key names that refer to the same topic or type in
+different services, complicating configuration as well as maintaining an idea of what
+is actually happening in our services wrt Kafka. To clarify, the configuration
+referred to is the various service-defined event subscriber and event publisher config
+containing `"abc_topic"` and `"abc_type"` fields.
+
+Example:  
+When a user requests to download a file that's not yet in the outbox/download bucket,
+the `DCS` fires an event to its *unstaged_download_event_topic*. The `IFRS` subscribes
+to this topic, but the topic name is assigned to its config option labeled
+*files_to_stage_topic*. Devs not familiar with this relationship between the two
+services could be forgiven for not realizing that the two configured topics
+are actually the same topic.
+Ideally, both services will refer to this topic with identical configuration.
+That is, the `DCS`'s config would also be named `files_to_stage_topic` (or vice-versa).
+
+Thankfully the majority of configuration *does* use the same names, but the
+issue can be completely resolved if we just standardize the config.
+After all, if we can define a schema for a given Kafka event in a library,
+then we can also define standardized config for the corresponding event topic and type.
+
+By storing this config definition in a central location, we also reduce change
+propagation & maintenance costs in the potential event that we drastically
+rework our Kafka layout. This could later be married with the currently dormant
+`schema_registry` so Kafka-related domain concepts are fully co-located.
+
+
+### Included/Required:
+- Standardized Config in `ghga-event-schemas` and release
+- Replace independent config implementations with the standardized versions
+- Chart/diagram/map explaining config name changes (e.g. to help update PROD config)
+
+### Not Included:
+- Tie new standard configs to the corresponding schema definitions in `schema_registry`
+
+## Additional Implementation Details:
+We already have an unofficial document mapping the relationships between all
+the various Kafka configurations, so this epic will lean on that information.
+Developer review will help identify mistakes.
+
+The standardization process will involve three steps:
+1. Identify services whose Kafka publisher or subscriber configuration refers to a common value, i.e. topic & type.
+2. Create a configuration class in `ghga-event-schemas` to standardize the config.
+3. Update services to use the standardized config classes as appropriate.
+
+The process will apply to all instances of Kafka event pub/sub config so that no
+such config is defined outside of `ghga-event-schemas`. After all, if a service
+publishes an event, presumably another service will consume that event, meaning they
+will have to share configuration. If the schema is centrally defined, the config
+should be too.
+
+### A Note on Normal Events Using the Outbox Pattern
+We have events that don't communicate state but that nevertheless use the
+outbox pattern solely for persistence. They always use the `upserted` event type
+because deletion isn't an applicable concept. The result is a shoehorned process
+that really needs a dedicated mechanism in `hexkit`. That mechanism, a class
+that mimics some of the outbox DAO's functionality, can be created in another epic.
+
+For this epic, **if** a config class in the chart below is *not*
+marked with \* but the current corresponding event types *are* dictated
+by `hexkit`'s outbox pattern event types, **then**:
+1. The event type's value going forward must be (temporarily) configured as `upserted`
+2. These are examples of places where the future stateless outbox DAO would be used
+   - Not exhaustive -- most non-outbox events would be eligible
+
+### Proposed Config Classes
+> \* means these events communicate state and should use the outbox pattern
+
+<table>
+<tr><th>New Config Class </th><th>Replaces </th></tr>
+<tr>
+<td><pre><code>
+<strong>*DatasetEventsConfig</strong>:
+   dataset_change_event_topic
+   dataset_deletion_type
+   dataset_upsertion_type
+</code></pre></td>
+<td><pre><code>
+UMS:
+  dataset_deletion_event_topic
+  dataset_deletion_event_type
+WPS & DINS:
+  dataset_change_event_topic
+  dataset_deletion_event_type
+  dataset_upsertion_event_type
+Metldata:
+  dataset_change_event_topic
+  dataset_deletion_type
+  dataset_upsertion_type
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>*ResourceEventsConfig</strong>:
+   resource_change_event_topic
+   resource_deletion_event_type
+   resource_upsertion_type
+</code></pre></td>
+<td><pre><code>
+Metldata & MASS:
+  resource_change_event_topic
+  resource_upsertion_type
+  resource_deletion_event_type
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>*UserEventsTopicConfig</strong>:
+   user_event_topic
+</code></pre></td>
+<td><pre><code>
+UMS & NOS:
+  user_events_topic
+  (event type managed by hexkit)
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>FileMetadataEventsConfig</strong>:
+   file_metadata_event_topic
+   file_metadata_event_type
+</code></pre></td>
+<td><pre><code>
+UCS:
+  file_metadata_event_topic
+  file_metadata_event_type
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>FileUploadReceivedEventsConfig</strong>:
+   file_upload_received_topic
+   file_upload_received_event_type
+</code></pre></td>
+<td><pre><code>
+(each currently use hexkit's outbox pattern event type)
+UCS:
+  file_upload_received_topic,
+IRS:
+  upload_received_event_topic
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>NotificationEventsConfig</strong>:
+   notification_event_topic
+   notification_event_type
+</code></pre></td>
+<td><pre><code>
+NS & NOS:
+  notification_event_topic
+  notification_event_type
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>FileStagingRequestedEventsConfig</strong>:
+   files_to_stage_event_topic
+   files_to_stage_event_type
+</code></pre></td>
+<td><pre><code>
+(both currently use hexkit's outbox pattern event type)
+IFRS:
+  files_to_stage_topic
+DCS:
+  unstaged_download_event_topic
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>FileStagedEventsConfig</strong>:
+   file_staged_event_topic
+   file_staged_event_type
+</code></pre></td>
+<td><pre><code>
+IFRS:
+  file_staged_event_topic
+  file_staged_event_type
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>DownloadServedEventsConfig</strong>:
+   download_served_event_topic
+   download_served_event_type
+</code></pre></td>
+<td><pre><code>
+DCS:
+  download_served_event_topic
+  download_served_event_type
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>FileDeletionRequestEventsConfig</strong>:
+   file_deletion_request_event_topic
+   file_deletion_request_event_type
+</code></pre></td>
+<td><pre><code>
+(each currently use hexkit's outbox pattern event type)
+PCS, IFRS, DCS, & UCS:
+  files_to_delete_topic
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>FileDeletedEventsConfig</strong>:
+   file_deleted_event_topic
+   file_deleted_event_type
+</code></pre></td>
+<td><pre><code>
+IFRS, DCS, & UCS:
+  file_deleted_event_topic
+  file_deleted_event_type
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>FileInterrogationSuccessEventsConfig</strong>:
+   file_interrogations_topic
+   interrogation_success_event_type
+</code></pre></td>
+<td><pre><code>
+(all currently use hexkit's outbox pattern event type)
+IRS & FIS:
+  file_upload_validation_success_topic
+IFRS:
+  files_to_register_topic
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>FileInterrogationFailureEventsConfig</strong>:
+   file_interrogations_topic
+   interrogation_failure_event_type
+</code></pre></td>
+<td><pre><code>
+IRS:
+  interrogation_topic
+  interrogation_failure_type
+UCS:
+  upload_rejected_event_topic
+  upload_rejected_event_type
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>FileInternallyRegisteredEventsConfig</strong>:
+   file_internally_registered_event_topic
+   file_internally_registered_event_type
+</code></pre></td>
+<td><pre><code>
+IFRS, DCS, IRS, DINS:
+  file_registered_event_topic
+  file_registered_event_type
+UCS:
+  upload_accepted_event_topic
+  upload_accepted_event_type
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>FileRegisteredForDownloadEventsConfig</strong>:
+   file_registered_for_download_event_topic
+   file_registered_for_download_event_type
+</code></pre></td>
+<td><pre><code>
+DCS:
+  files_to_register_topic
+  files_to_register_type
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>AccessRequestCreatedEventsConfig</strong>:
+   access_request_event_topic
+   access_request_created_event_type
+</code></pre></td>
+<td><pre><code>
+NOS & ARS:
+  access_request_events_topic
+  access_request_created_event_type
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>AccessRequestAllowedEventsConfig</strong>:
+   access_request_event_topic
+   access_request_allowed_event_type
+</code></pre></td>
+<td><pre><code>
+NOS & ARS:
+  access_request_events_topic
+  access_request_allowed_event_type
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>AccessRequestDeniedEventsConfig</strong>:
+   access_request_event_topic
+   access_request_denied_event_type
+</code></pre></td>
+<td><pre><code>
+NOS & ARS:
+  access_request_events_topic
+  access_request_denied_event_type
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>IvaChangeEventsConfig</strong>:
+   iva_state_changed_event_topic
+   iva_state_changed_event_type
+</code></pre></td>
+<td><pre><code>
+NOS:
+  iva_state_changed_event_topic
+  iva_state_changed_event_type
+UMS:
+  iva_events_topic
+  iva_state_changed_event_type
+</code></pre></td>
+</tr>
+
+<tr>
+<td><pre><code>
+<strong>SecondFactorRecreatedEventsConfig</strong>:
+   auth_event_topic
+   second_factor_recreated_event_type
+</code></pre></td>
+<td><pre><code>
+NOS:
+  second_factor_recreated_event_topic
+  second_factor_recreated_event_type
+UMS:
+  auth_events_topic
+  second_factor_recreated_event_type
+</code></pre></td>
+</tr>
+
+</table>
+
+
+## Human Resource/Time Estimation:
+
+Number of sprints required: 1
+
+Number of developers required: 1

--- a/README.md
+++ b/README.md
@@ -73,3 +73,4 @@ This repository is part of the [Epic Planning and Marathon SOP](https://docs.ghg
 - (64) [Blue Whale](./64-blue-whale/technical_specification.md): Reimplement frontend features in Angular
 - (65) [Striped Skunk](./65-striped-skunk/technical_specification.md): Hexkit v4 Rollout
 - (66) [Irukandji](./66-irukandji/technical_specification.md): Schemapack
+- (67) [Oryx](./67-oryx/technical_specification.md): Kafka Event Config Standardization


### PR DESCRIPTION
Discusses a way to standardize Kafka event topic/type configurations. 

Question: would it make sense to drop "Events" from the config class titles for brevity?